### PR TITLE
Make the page faster

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ window.innerHeight;
   }
   </script>
 </head>
-<body onload="debug();">
+<body>
   <div id="container">
     <header>
       <div id="gliders">


### PR DESCRIPTION
The updating of debug box (which is `display: none`) every second is not neccessary. And it slows down the site.